### PR TITLE
Fastq format bugfix

### DIFF
--- a/internals/cpp-src/src/ReadTrimmer.cpp
+++ b/internals/cpp-src/src/ReadTrimmer.cpp
@@ -143,7 +143,7 @@ namespace read_trimmer {
             block[k] = line;
             k++;
             if (k > 3) {
-                if (block[0].substr(0, 1) != "@" or block[2] != "+") {
+                if (block[0].substr(0, 1) != "@" or block[2].substr(0, 1) != "+") {
                     throw std::runtime_error("ERROR: Input file " + filename + " does not appear FASTQ formatted.");
                 }
             

--- a/internals/python/pyshapemap/components.py
+++ b/internals/python/pyshapemap/components.py
@@ -1966,7 +1966,9 @@ class CorrectSequence(Component):
             self.add(appender.appended, alias="corrected")
 
         else:
-            parser = MutationParser(min_mapq=min_mapq,
+            parser = MutationParser(name="MutationParser",
+                                    assoc_rna=target_names[0],
+                                    min_mapq=min_mapq,
                                     min_qual=min_qual_to_count,
                                     random_primer_len=random_primer_len,
                                     maxins=maxins,
@@ -1976,7 +1978,9 @@ class CorrectSequence(Component):
                                     require_reverse_primer_mapped=require_reverse_primer_mapped,
                                     trim_primers=trim_primers,
                                     )
-            counter = MutationCounter(variant_out=True,
+            counter = MutationCounter(name="MutationCounter",
+                                      assoc_rna=target_names[0],
+                                      variant_out=True,
                                       mutations_out=False,
                                       target_length=target_lengths[0])
             connect(sample.aligned, parser.input)
@@ -1984,7 +1988,9 @@ class CorrectSequence(Component):
             self.add([parser,
                       counter])
 
-            sequencefixer = SequenceCorrector(mindepth=min_seq_depth,
+            sequencefixer = SequenceCorrector(name="MutationParser",
+                                              assoc_rna=target_names[0],
+                                              mindepth=min_seq_depth,
                                               minfreq=min_freq)  # FIXME: keep param names consistent across codebase
             self.add(sequencefixer)
             connect(prep.target.input_node, sequencefixer.target)


### PR DESCRIPTION
2 bug fixes:
1. '+' entry of fastq files were not allowed to have content, despite being valid fastq format, and ShapeMapper2 not caring about this content. Very annoying for SRA file downloads.
2. `--amplicon` and `--correct-seq` used simultaneously produced an error because MutationCounter, MutationParser, and SequenceCorrector components were not given names or associated RNA targets. See issue #31.

Tony or Lucas, can you double check these? We have been using them in Shapemapper 2.1.5 with no issues yet, but untested with 2.2.0.