### PR TITLE
add EasyBuild install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ ShapeMapper will only run on 64-bit Linux systems (Mac and Windows are not curre
 - Alternatively, you can build ShapeMapper if the provided binaries do not run on your platform. 
   Building is relatively straightforward using conda. See <a href="docs/building.md">building</a>.
 
+- If your site uses EasyBuild for managing scientific software, ShapeMapper2 can be installed with
+  EasyBuild. `eb ShapeMapper2-2.3-GCC-13.3.eb`
+  
 <!-- #### -->
 
 Usage


### PR DESCRIPTION
I have created an easyconfig for installing Shapemapper2 for HPC sites that use EasyBuild.  View the easyconfig [here](https://github.com/easybuilders/easybuild-easyconfigs/pull/22922)

This PR contains patches for boost, and Python.  The Python code is enough to fix issues with shapemapper -v and -help.

